### PR TITLE
Implement whitelisting for translations

### DIFF
--- a/l10n_mapper_generator/build.yaml
+++ b/l10n_mapper_generator/build.yaml
@@ -10,4 +10,5 @@ builders:
         l10n: true
         locale: true
         parseL10n: true
-        message: null
+        message: null,
+        mapper-whitelist: []

--- a/l10n_mapper_generator/lib/l10n_mapper_builder.dart
+++ b/l10n_mapper_generator/lib/l10n_mapper_builder.dart
@@ -14,6 +14,7 @@ Builder l10nMapperBuilder(BuilderOptions options) {
   final locale = options.config['locale'] as bool? ?? true;
   final parseL10n = options.config['parseL10n'] as bool? ?? true;
   final message = options.config['message'] as String?;
+  final mapperWhitelist = (options.config['mapper-whitelist'] as List<dynamic>?)?.map<String>((item) => item.toString()).toList() ?? [];
 
   return LibraryBuilder(
     L10nMapperGenerator(
@@ -21,6 +22,7 @@ Builder l10nMapperBuilder(BuilderOptions options) {
       locale: locale,
       parseL10n: parseL10n,
       message: message,
+      mapperWhitelist: mapperWhitelist,
     ),
     generatedExtension: '.mapper.dart',
   );

--- a/l10n_mapper_generator/lib/l10n_mapper_generator.dart
+++ b/l10n_mapper_generator/lib/l10n_mapper_generator.dart
@@ -22,7 +22,16 @@ class L10nMapperGenerator extends Generator {
   //? nullable values when key is not found but will return specified error message instead
   final String? message;
 
-  L10nMapperGenerator({required this.l10n, required this.locale, required this.parseL10n, required this.message});
+  /// only items from the mapperWhitelist will be included in the map
+   final List<String> mapperWhitelist;
+
+  L10nMapperGenerator({
+    required this.l10n, 
+    required this.locale, 
+    required this.parseL10n, 
+    required this.message,
+    this.mapperWhitelist = const [],
+  });
 
   @override
   FutureOr<String?> generate(LibraryReader library, BuildStep buildStep) {
@@ -98,6 +107,9 @@ class L10nMapperGenerator extends Generator {
           // skips gen-exceptions
           if (genExceptions.contains(name)) continue;
 
+          // skip fields not in mapperWhitelist
+          if (mapperWhitelist.isNotEmpty && !mapperWhitelist.contains(name)) continue;
+
           buffer.writeln("'$name': localizations.$name,");
         }
 
@@ -107,6 +119,10 @@ class L10nMapperGenerator extends Generator {
 
           // skips gen-exceptions
           if (genExceptions.contains(name)) continue;
+          
+          // skip fields not in mapperWhitelist
+          if (mapperWhitelist.isNotEmpty && !mapperWhitelist.contains(name)) continue;
+
           final parameters = method.parameters.map((e) => e.name).join(', ');
 
           buffer.writeln("'$name': ($parameters) => localizations.$name($parameters),");

--- a/l10n_mapper_generator/pubspec.yaml
+++ b/l10n_mapper_generator/pubspec.yaml
@@ -22,8 +22,9 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.3.3
   flutter_lints: ^3.0.2
-  flutter_test:
-    sdk: flutter
+  test: ^1.25.2
+  # flutter_test:
+  #   sdk: flutter
 
 executables:
   l10n_mapper_generator: l10n_mapper_generator

--- a/l10n_mapper_generator/test/l10_mapper_generator_test.dart
+++ b/l10n_mapper_generator/test/l10_mapper_generator_test.dart
@@ -1,1 +1,37 @@
-void main() {}
+// ignore: non_constant_identifier_names
+import 'package:test/test.dart';
+import 'package:l10n_mapper_generator/l10n_mapper_generator.dart';
+
+void main() {
+  group('L10nMapperGenerator', () {
+    test('correct values to props and nullable props', () {
+      final generator = L10nMapperGenerator(
+        l10n: true, 
+        locale: true, 
+        parseL10n: true, 
+        message: 'test', 
+      );
+      expect(generator.l10n, equals(true));
+      expect(generator.locale, equals(true));
+      expect(generator.parseL10n, equals(true));
+      expect(generator.message, equals('test'));
+      expect(generator.mapperWhitelist, equals([]));
+    });
+
+    test('correct values to props', () {
+      final generator = L10nMapperGenerator(
+        l10n: true, 
+        locale: true, 
+        parseL10n: true, 
+        message: 'test', 
+        mapperWhitelist: ['test'], 
+      );
+      expect(generator.l10n, equals(true));
+      expect(generator.locale, equals(true));
+      expect(generator.parseL10n, equals(true));
+      expect(generator.message, equals('test'));
+      expect(generator.mapperWhitelist, equals(['test']));
+    });
+  });
+
+}


### PR DESCRIPTION
add: mapper-whitelist to the build configuration
add: mapperWhitelist param to the Generator
change: bypass items that are not in the whitelist when generating the map

## Description

Provides a way to limit the translations placed in the map. Most probably users would not want all the translations be accessible via dynamic keys coming from somewhere else. In my case I want only the form validations errors exposed to parsel10n

## Please check the following boxes

<!--- Put an `X` in all the boxes that apply: -->

- [x] Pull Request title is consistent with the implemented feature, fix etc.
- [x] I have followed proper descriptive code style and conventions
- [x] The code is self-documenting and has no unnecessary comments. I named the functions and variables to clearly describe their purpose.
- [ ] I have added Unit Tests and coverage is 70%+
- [x] I have tested and verified this implementation and it works as expected
