### PR TITLE
[FIX] Dynamically generate import path for AppLocalizations in buffer

### DIFF
--- a/l10n_mapper_generator/lib/l10n_mapper_generator.dart
+++ b/l10n_mapper_generator/lib/l10n_mapper_generator.dart
@@ -31,6 +31,7 @@ class L10nMapperGenerator extends Generator {
     for (var classElement in library.classes.where((c) => c.isAbstract)) {
       if (classElement.displayName == 'AppLocalizations') {
         final className = classElement.displayName;
+        final localizationPath = classElement.source.uri;
         final mapperName = '${classElement.displayName}Mapper';
         final extensionName = '${classElement.displayName}Extension';
 
@@ -38,7 +39,7 @@ class L10nMapperGenerator extends Generator {
         final shouldGenerateExtension = l10n || locale || parseL10n;
 
         // import
-        buffer.writeln("import 'app_localizations.dart';");
+        buffer.writeln("import '$localizationPath';");
         buffer.writeln("import 'package:flutter/widgets.dart';");
 
         // generate extension


### PR DESCRIPTION
## Description

<!--- Describe briefly what this pull request does -->

This pull request dynamically determines the import path for AppLocalizations based on the source URI of the classElement, replacing the static 'app_localizations.dart' import. This ensures flexibility in handling different localization setups.

<!--- Put an `X` in all the boxes that apply: -->

- [x] Pull Request title is consistent with the implemented feature, fix etc.
- [ ] I have followed proper descriptive code style and conventions
- [ ] The code is self-documenting and has no unnecessary comments. I named the functions and variables to clearly describe their purpose.
- [ ] I have added Unit Tests and coverage is 70%+
- [ ] I have tested and verified this implementation and it works as expected
