### PR TITLE
[bugfix-45] Add type casting for Function.apply in L10nHelper methods

### DIFF
--- a/docs/technical/BEFORE_AFTER.md
+++ b/docs/technical/BEFORE_AFTER.md
@@ -20,7 +20,7 @@ class L10nHelper {
     
     if (object == null) return 'Translation key not found!';
     if (object is String) return object;
-    return Function.apply(object, arguments) as String;
+    return Function.apply(object as Function, arguments) as String;
   }
 }
 ```

--- a/docs/technical/GENERATED_OUTPUT.md
+++ b/docs/technical/GENERATED_OUTPUT.md
@@ -82,7 +82,7 @@ class L10nHelper {
     if (object is String) return object;
     assert(arguments != null, 'Arguments should not be null!');
     assert(arguments!.isNotEmpty, 'Arguments should not be empty!');
-    return Function.apply(object, arguments) as String;
+    return Function.apply(object as Function, arguments) as String;
   }
 
   static void clearCache([String? localeName]) {

--- a/docs/technical/WORKFLOW.md
+++ b/docs/technical/WORKFLOW.md
@@ -201,7 +201,7 @@ class L10nHelper {
     if (object is String) return object;
     
     // For parameterized translations
-    return Function.apply(object, arguments) as String;
+    return Function.apply(object as Function, arguments) as String;
   }
 }
 

--- a/example/lib/localization/gen-l10n/app_localizations.mapper.dart
+++ b/example/lib/localization/gen-l10n/app_localizations.mapper.dart
@@ -48,7 +48,7 @@ class L10nHelper {
     if (object is String) return object;
     assert(arguments != null, 'Arguments should not be null!');
     assert(arguments!.isNotEmpty, 'Arguments should not be empty!');
-    return Function.apply(object, arguments) as String;
+    return Function.apply(object as Function, arguments) as String;
   }
 
   /// Clear the cache for a specific locale or all locales

--- a/l10n_mapper_generator/lib/l10n_mapper_generator.dart
+++ b/l10n_mapper_generator/lib/l10n_mapper_generator.dart
@@ -121,7 +121,8 @@ class L10nMapperGenerator extends Generator {
             bufferL10nHelper.writeln("assert(arguments != null, 'Arguments should not be null!');");
             bufferL10nHelper.writeln("assert(arguments!.isNotEmpty, 'Arguments should not be empty!');");
 
-            bufferL10nHelper.writeln('return Function.apply(object, arguments) as String;');
+            bufferL10nHelper.writeln(
+                'return Function.apply(object as Function, arguments) as String;');
             bufferL10nHelper.writeln('}');
             bufferL10nHelper.writeln('');
             bufferL10nHelper.writeln('/// Clear the cache for a specific locale or all locales');


### PR DESCRIPTION
## Description

Issue #45 - Add type casting for Function.apply in L10nHelper methods

Updated the L10nHelper methods across multiple files to ensure proper type casting of the object parameter in Function.apply, preventing potential type mismatch issues. This change enhances type safety and consistency in localization handling.

## Please check the following boxes

<!--- Put an `X` in all the boxes that apply: -->

- [x] Pull Request title is consistent with the implemented feature, fix etc.
- [x] I have followed proper descriptive code style and conventions
- [x] The code is self-documenting and has no unnecessary comments. I named the functions and variables to clearly describe their purpose.
- [ ] I have added Unit Tests and coverage is 70%+
- [x] I have tested and verified this implementation and it works as expected
